### PR TITLE
Add migration to boostrap GuardianTrackable fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore tmp directory used during tests
+/priv/tmp

--- a/lib/mix/tasks/guardian_trackable.install.ex
+++ b/lib/mix/tasks/guardian_trackable.install.ex
@@ -1,0 +1,65 @@
+defmodule Mix.Tasks.GuardianTrackable.Install do
+  @shortdoc "Generates a new migration for GuardianTrackable"
+
+  @moduledoc """
+  Generates a migration.
+
+  The repository must be set under `:ecto_repos` in the
+  current app configuration or given via the `-r` option.
+
+  This generator follows the functionality of `ecto.gen.migration`, so it will
+  be created in the configured migration direction with a timestamp-prefixed
+  filename.
+
+  ## Examples
+
+      mix guardian_trackable.install
+      mix guardian_trackable.install -r Custom.Repo
+      mix guardian_trackable.install --schema accounts
+
+  ## Command line options
+
+    * `-r`, `--repo` - the repo to generate migration for
+    * `--schema` - the schema to generate migration for
+  """
+  use Mix.Task
+
+  import Mix.Ecto
+  import Mix.Generator
+
+  @doc false
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, switches: [schema: :string])
+
+    no_umbrella!("ecto.gen.migration")
+    repos = parse_repo(args)
+
+    Enum.each(repos, fn repo ->
+      ensure_repo(repo, args)
+      path = migrations_path(repo)
+      file = Path.join(path, "#{timestamp()}_guardian_trackable.exs")
+      create_directory(path)
+
+      assigns = [
+        mod: Module.concat([repo, Migrations, "GuardianTrackable"]) |> inspect,
+        schema: Keyword.get(opts, :schema, "users")
+      ]
+
+      source_path =
+        :guardian_trackable
+        |> Application.app_dir()
+        |> Path.join("priv/templates/migration.exs.eex")
+
+      migration_template = EEx.eval_file(source_path, assigns)
+      create_file(file, migration_template)
+    end)
+  end
+
+  defp timestamp do
+    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
+  end
+
+  defp pad(i) when i < 10, do: << ?0, ?0 + i >>
+  defp pad(i), do: to_string(i)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,14 @@ defmodule GuardianTrackable.Mixfile do
   defp package do
     [
       description: "A Guardian hook to track user sign in.",
-      files: ["lib", "config", "mix.exs", "README.md", "LICENSE.txt"],
+      files: [
+        "lib",
+        "config",
+        "mix.exs",
+        "README.md",
+        "LICENSE.txt",
+        "priv/templates"
+      ],
       maintainers: ["Ray Zane"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/promptworks/guardian_trackable"}

--- a/priv/templates/migration.exs.eex
+++ b/priv/templates/migration.exs.eex
@@ -1,0 +1,13 @@
+defmodule <%= mod %> do
+  use Ecto.Migration
+
+  def change do
+    alter table(:<%= schema %>) do
+      add :sign_in_count, :integer, default: 0
+      add :last_sign_in_ip, :string
+      add :last_sign_in_at, :utc_datetime
+      add :current_sign_in_ip, :string
+      add :current_sign_in_at, :utc_datetime
+    end
+  end
+end

--- a/test/mix/tasks/guardian_trackable.install_test.exs
+++ b/test/mix/tasks/guardian_trackable.install_test.exs
@@ -1,0 +1,57 @@
+defmodule Mix.Tasks.Guardian.Db.Gen.MigrationTest do
+  use GuardianTrackable.DataCase, async: true
+  import Mix.Tasks.GuardianTrackable.Install, only: [run: 1]
+
+  @tmp_path Path.join(["priv", "tmp"])
+  @migrations_path Path.join([@tmp_path, "migrations"])
+
+  defmodule DoubleDummy.Repo do
+    def __adapter__ do
+      true
+    end
+
+    def config do
+      [
+        priv: "priv/tmp/double_dummy",
+        otp_app: :guardian_trackable
+      ]
+    end
+  end
+
+  setup_all do
+    Application.put_env(
+      :guardian_trackable,
+      GuardianTrackable.Dummy.Repo,
+      priv: "priv/tmp"
+    )
+  end
+
+  setup do
+    on_exit(fn -> File.rm_rf!(@tmp_path) end)
+    :ok
+  end
+
+  test "generates a new migration" do
+    run([])
+
+    assert name = File.ls!(@migrations_path) |> List.last
+    assert String.match?(name, ~r/^\d{14}_guardian_trackable\.exs$/)
+  end
+
+  test "generates a new migration with repo" do
+    run(["-r", to_string(DoubleDummy.Repo)])
+
+    assert name = File.ls!("priv/tmp/double_dummy/migrations") |> List.last
+    assert String.match?(name, ~r/^\d{14}_guardian_trackable\.exs$/)
+  end
+
+  test "generates a new migration with schema" do
+    run(["--schema", "accounts"])
+
+    assert name = File.ls!(@migrations_path) |> List.last
+    assert @migrations_path
+      |> Path.join(name)
+      |> File.read!
+      |> String.match?(~r/:accounts/)
+  end
+end


### PR DESCRIPTION
This commit adds a migration generator to easily add the fields
GuardianTrackable requires to a repo.

Usage:
```
mix guardian_trackable.install
mix guardian_trackable.install -r Custom.repo
mix guardian_trackable.install --schema accounts
```

By default uses the repo configured in the app's config and the `users` schema,
both of which can be customized.

The generator follows the functionality of `ecto.gen.migration`, so results
should be similar.

Heavy influence taken from [`ecto.gen.migration`] and [`guardian.db.gen.migration`]

Closes #1

[`ecto.gen.migration`]: https://github.com/elixir-ecto/ecto/blob/42d47a6da0711f842e1a0e6724a89b318b9b2144/lib/mix/tasks/ecto.gen.migration.ex
[`guardian.db.gen.migration`]: https://github.com/ueberauth/guardian_db/blob/25cae4aa63f4d944e9c9c5795b9da59b5fd5ce3f/lib/mix/tasks/guardian_db.gen.migration.ex